### PR TITLE
Allocate less by using Cow

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -8,30 +8,30 @@ use media_types::*;
 #[test]
 fn test_text_plain() {
     let tag: MediaType = "text/plain".parse().unwrap();
-    assert_eq!(tag.type_, Some("text".to_owned()));
-    assert_eq!(tag.subtype, Some("plain".to_owned()));
+    assert_eq!(tag.type_, Some("text".into()));
+    assert_eq!(tag.subtype, Some("plain".into()));
 }
 
 #[test]
 fn test_application_vnd_oasis_opendocument_text() {
     let tag: MediaType = "application/vnd.oasis.opendocument.text".parse().unwrap();
-    assert_eq!(tag.type_, Some("application".to_owned()));
-    assert_eq!(tag.tree, Some("vnd".to_owned()));
-    assert_eq!(tag.subtype, Some("oasis.opendocument.text".to_owned()));
+    assert_eq!(tag.type_, Some("application".into()));
+    assert_eq!(tag.tree, Some("vnd".into()));
+    assert_eq!(tag.subtype, Some("oasis.opendocument.text".into()));
 }
 
 #[test]
 fn test_image_svg_xml() {
     let tag: MediaType = "image/svg+xml".parse().unwrap();
-    assert_eq!(tag.type_, Some("image".to_owned()));
-    assert_eq!(tag.subtype, Some("svg".to_owned()));
-    assert_eq!(tag.suffix, Some("xml".to_owned()));
+    assert_eq!(tag.type_, Some("image".into()));
+    assert_eq!(tag.subtype, Some("svg".into()));
+    assert_eq!(tag.suffix, Some("xml".into()));
 }
 
 #[test]
 fn test_audio_star() {
     let tag: MediaType = "audio/*".parse().unwrap();
-    assert_eq!(tag.type_, Some("audio".to_owned()));
+    assert_eq!(tag.type_, Some("audio".into()));
     assert_eq!(tag.subtype, None);
 }
 
@@ -50,31 +50,31 @@ fn test_empty() {
 fn test_rfc6381_types() {
     let tag: MediaType = "video/3gpp2; codecs=\"sevc, s263\"".parse().unwrap();
     let mut parameters = HashMap::new();
-    parameters.insert("codecs".to_owned(), "sevc, s263".to_owned());
+    parameters.insert("codecs".into(), "sevc, s263".into());
     assert_eq!(tag.parameters, parameters);
     let tag: MediaType = "audio/3gpp2; codecs=mp4a.E1".parse().unwrap();
     let mut parameters = HashMap::new();
-    parameters.insert("codecs".to_owned(), "mp4a.E1".to_owned());
+    parameters.insert("codecs".into(), "mp4a.E1".into());
     assert_eq!(tag.parameters, parameters);
 
     let tag: MediaType = "example/*; codecs=a.bb.ccc.d".parse().unwrap();
     let mut parameters = HashMap::new();
-    parameters.insert("codecs".to_owned(), "a.bb.ccc.d".to_owned());
+    parameters.insert("codecs".into(), "a.bb.ccc.d".into());
     assert_eq!(tag.parameters, parameters);
 
     let tag: MediaType = "example/*; codecs=\"a.bb.ccc.d, e.fff\"".parse().unwrap();
     let mut parameters = HashMap::new();
-    parameters.insert("codecs".to_owned(), "a.bb.ccc.d, e.fff".to_owned());
+    parameters.insert("codecs".into(), "a.bb.ccc.d, e.fff".into());
     assert_eq!(tag.parameters, parameters);
 
     let tag: MediaType = "example/*; codecs*=''fo%2e".parse().unwrap();
     let mut parameters = HashMap::new();
-    parameters.insert("codecs".to_owned(), "fo.".to_owned());
+    parameters.insert("codecs".into(), "fo.".into());
     assert_eq!(tag.parameters, parameters);
 
     let tag: MediaType = "example/*; codecs*=\"''%25%20xz, gork\"".parse().unwrap();
     let mut parameters = HashMap::new();
-    parameters.insert("codecs".to_owned(), "% xz, gork".to_owned());
+    parameters.insert("codecs".into(), "% xz, gork".into());
     assert_eq!(tag.parameters, parameters);
 }
 
@@ -82,9 +82,9 @@ fn test_rfc6381_types() {
 fn test_rfc2231_types() {
     let tag: MediaType = "application/x-stuff; title*=us-ascii'en-us'This is%20%2A%2A%2Afun%2A%2A%2A".parse().unwrap();
     let mut expected: MediaType = Default::default();
-    expected.type_ = Some("application".to_owned());
-    expected.subtype = Some("x-stuff".to_owned());
-    expected.parameters.insert("title".to_owned(), "This is ***fun***".to_owned());
+    expected.type_ = Some("application".into());
+    expected.subtype = Some("x-stuff".into());
+    expected.parameters.insert("title".into(), "This is ***fun***".into());
     assert_eq!(tag, expected);
 }
 
@@ -92,9 +92,9 @@ fn test_rfc2231_types() {
 fn test_rfc1341_types() {
     let tag: MediaType = "multipart/digest; boundary=\"---- next message ----\" ".parse().unwrap();
     let mut expected: MediaType = Default::default();
-    expected.type_ = Some("multipart".to_owned());
-    expected.subtype = Some("digest".to_owned());
-    expected.parameters.insert("boundary".to_owned(), "---- next message ----".to_owned());
+    expected.type_ = Some("multipart".into());
+    expected.subtype = Some("digest".into());
+    expected.parameters.insert("boundary".into(), "---- next message ----".into());
     assert_eq!(tag, expected);
     assert_eq!(tag.boundary(), Ok("---- next message ----"));
 
@@ -119,18 +119,18 @@ fn test_rfc2046_types() {
 
 #[test]
 fn test_format() {
-    let mut tag = MediaType::new(Some("example"), STANDARDS, Some("foobar"), None);
+    let mut tag = MediaType::new(Some("example"), STANDARDS, Some("foobar"));
     assert_eq!(tag.to_string(), "example/foobar");
-    tag = MediaType::new(Some("example"), Some("spam"), Some("foobar"), None);
+    tag = MediaType::new(Some("example"), Some("spam"), Some("foobar"));
     assert_eq!(tag.to_string(), "example/spam.foobar");
-    tag = MediaType::new(Some("example"), UNREGISTERED, Some("foobar"), None);
+    tag = MediaType::new(Some("example"), UNREGISTERED, Some("foobar"));
     assert_eq!(tag.to_string(), "example/x.foobar");
-    tag = MediaType::new(Some("example"), UNREGISTERED, Some("foobar"), Some("xml"));
+    tag = MediaType::new_with_suffix(Some("example"), UNREGISTERED, Some("foobar"), Some("xml"));
     assert_eq!(tag.to_string(), "example/x.foobar+xml");
-    tag.parameters.insert("charset".to_owned(), "US-ASCII".to_owned());
+    tag.parameters.insert("charset".into(), "US-ASCII".into());
     assert_eq!(tag.to_string(), "example/x.foobar+xml; charset=US-ASCII");
-    tag.parameters.insert("boundary".to_owned(), "foo ,".to_owned());
+    tag.parameters.insert("boundary".into(), "foo ,".into());
     assert_eq!(tag.to_string(), "example/x.foobar+xml; boundary=\"foo ,\"; charset=US-ASCII");
-    tag.parameters.insert("z".to_owned(), "1".to_owned());
+    tag.parameters.insert("z".into(), "1".into());
     assert_eq!(tag.to_string(), "example/x.foobar+xml; boundary=\"foo ,\"; charset=US-ASCII; z=1");
 }


### PR DESCRIPTION
It seems unnecessary to require an allocation when most of these will be statically-known/hardcoded. e.g. `MediaType::is_font_type` potentially allocates 20+ `String`s just to do a comparison. (although I'd largely hope LLVM would reduce that)

Additional Breaking change:
`MediaType::new` no longer takes a parameter for suffix, there is
a new constructor `MediaType::new_with_suffix` to cater for this.
